### PR TITLE
Stop using StaticStorages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,9 +3,6 @@ uuid = "e27abb06-81da-40e5-a77a-80f0fe2578fc"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
 version = "0.1.0-DEV"
 
-[deps]
-StaticStorages = "ee8d4ff6-3960-4079-a45c-572c714b7398"
-
 [compat]
 julia = "1"
 

--- a/src/PublicAPI.jl
+++ b/src/PublicAPI.jl
@@ -12,8 +12,6 @@ module Internal
 using ..PublicAPI: PublicAPI
 import ..PublicAPI: @public, @strict
 
-import StaticStorages
-
 include("registry.jl")
 include("query.jl")
 include("imports.jl")


### PR DESCRIPTION
It turned out it's much simpler to not use StaticStorages.jl for the API registry.