### PR TITLE
Use a shim module for strict import

### DIFF
--- a/src/imports.jl
+++ b/src/imports.jl
@@ -1,22 +1,63 @@
 # TODO: Support `import` for APIs marked as overloadbale
-# TODO: For `using M`, create a shim bare module `B` that only includes exported
-# names and then `const M = B; using .M`.
 """
     PublicAPI.@strict using Module: name₁, name₂, …, nameₙ
+    PublicAPI.@strict using Module
+    PublicAPI.@strict import Module
 
-Enable strict import; i.e., fail on importing non-public API.
+Enable strict import; i.e., fail on using non-public API.
+
+The simple forms `using Module` and `import Module` create a dummy object named
+`Module` that acts like the original `Module` but forbids access to the internal
+names.
+
+# Extended help
+
+Limitation: Currently, `PublicAPI.@strict` with the simple forms `using Module`
+and `import Module` creates a dummy local module and a global constant named
+`Module` is bind to it.  Thus, unlike `using Module`, the expression
+`PublicAPI.@strict using Module` cannot be evaluated more than once inside a
+module.  This is an implementation detail that may be fixed in the future if we
+find a better implementation.
 """
 macro strict(import_statement::Expr)
-    if !(
-        import_statement.head === :using &&
-        length(import_statement.args) == 1 &&
-        all((ex -> Meta.isexpr(ex, :., 1)), import_statement.args[1].args)
-    )
+    @gensym source_module
+    if is_explicit_using(import_statement)  # using M: a.b.c
+        import_expr = import_statement
+        M = import_statement.args[1].args[1]
+
+        imported_names = map(import_statement.args[1].args[2:end]) do ex
+            @assert Meta.isexpr(ex, :., 1)   # what else?
+            ex.args[1]::Symbol
+        end
+    elseif is_simple_using(import_statement) || is_simple_import(import_statement)
+        fullpath = import_statement.args[1].args
+        shim = gensym("PublicAPI_wrapper_" * join(fullpath, "."))
+        lastname = fullpath[end]::Symbol
+        import_expr = quote
+            baremodule $shim
+            $(Expr(:import, import_statement.args[1]))
+            for api in $PublicAPI.of($lastname)
+                name = $nameof(api)
+                $Base.@eval $shim const $(Expr(:$, :name)) =
+                    $lastname.$(Expr(:$, :name))
+            end
+            for name in $names($lastname)
+                $Base.@eval $shim export $(Expr(:$, :name))
+            end
+            end
+            const $lastname = $shim
+            if $(is_simple_using(import_statement))
+                using .$shim
+            end
+        end
+        @assert import_expr.head === :block
+        import_expr = Expr(:toplevel, import_expr.args...)
+        M = import_statement.args[1]
+        imported_names = Symbol[]  # no need to check
+    else
         error("Unsupported syntax: ", import_statement)
     end
 
-    @gensym source_module
-    M = import_statement.args[1].args[1]
     if VERSION ≥ v"1.6"
         import_source_module = Expr(:import, Expr(:as, M, source_module))
     else
@@ -32,18 +73,42 @@ macro strict(import_statement::Expr)
         import_source_module = Expr(:toplevel, import_source_module.args...)
     end
 
-    imported_names = map(import_statement.args[1].args[2:end]) do ex
-        @assert Meta.isexpr(ex, :., 1)   # what else?
-        ex.args[1]::Symbol
-    end
-
     quote
-        $import_statement # using M: a, b, c
+        $import_expr # e.g., using M: a, b, c
         $import_source_module # import M as $source_module
         $strict_check($source_module, $(QuoteNode(imported_names)))
         nothing
     end |> esc
 end
+
+"""
+    is_simple_using(ex::Expr) :: Bool
+
+Check if `ex` is of the form `using Module`.
+"""
+is_simple_using(ex::Expr, head = :using) =
+    ex.head === head &&
+    length(ex.args) == 1 &&
+    Meta.isexpr(ex.args[1], :., 1) &&
+    all(x -> x isa Symbol, ex.args[1].args)
+
+"""
+    is_simple_import(ex::Expr) :: Bool
+
+Check if `ex` is of the form `import Module`.
+"""
+is_simple_import(ex::Expr) = is_simple_using(ex, :import)
+
+"""
+    is_explicit_using(ex::Expr) :: Bool
+
+Check if `ex` is of the form `using Module: name₁, name₂, …, nameₙ`.
+"""
+is_explicit_using(ex::Expr) =
+    ex.head === :using &&
+    length(ex.args) == 1 &&
+    Meta.isexpr(ex.args[1], :(:)) &&
+    all((x -> Meta.isexpr(x, :., 1)), ex.args[1].args)
 
 function strict_check(source_module::Module, imported_names::Vector{Symbol})
     internals = setdiff(imported_names, nameof.(PublicAPI.of(source_module)))

--- a/test/PublicAPITests/src/PublicAPITests.jl
+++ b/test/PublicAPITests/src/PublicAPITests.jl
@@ -14,6 +14,7 @@ end  # module InplaceSamples
 include("utils.jl")
 include("test_samples.jl")
 include("test_query.jl")
+include("test_imports.jl")
 include("test_doctest.jl")
 
 end  # module PublicAPITests

--- a/test/PublicAPITests/src/test_imports.jl
+++ b/test/PublicAPITests/src/test_imports.jl
@@ -1,0 +1,38 @@
+module TestImports
+
+using Test
+
+module Indirection
+import PublicAPI
+end
+
+module StrictUsing
+using ..Indirection
+Indirection.PublicAPI.@strict using PublicAPI
+end
+
+module StrictImport
+using ..Indirection
+Indirection.PublicAPI.@strict import PublicAPI
+end
+
+function check_common(m::Module)
+    @test !isdefined(m, Symbol("@strict"))
+    @test !isdefined(m, :of)
+    @test isdefined(m.PublicAPI, Symbol("@public"))
+    @test isdefined(m.PublicAPI, Symbol("@strict"))
+    @test isdefined(m.PublicAPI, :of)
+    @test !isdefined(m.PublicAPI, :Internal)
+end
+
+function test_strict_using()
+    @test isdefined(StrictUsing, Symbol("@public"))
+    check_common(StrictUsing)
+end
+
+function test_strict_import()
+    @test !isdefined(StrictImport, Symbol("@public"))
+    check_common(StrictImport)
+end
+
+end  # module

--- a/test/PublicAPITests/src/test_imports.jl
+++ b/test/PublicAPITests/src/test_imports.jl
@@ -6,33 +6,19 @@ module Indirection
 import PublicAPI
 end
 
-module StrictUsing
-using ..Indirection
-Indirection.PublicAPI.@strict using PublicAPI
-end
-
 module StrictImport
 using ..Indirection
 Indirection.PublicAPI.@strict import PublicAPI
 end
 
-function check_common(m::Module)
-    @test !isdefined(m, Symbol("@strict"))
-    @test !isdefined(m, :of)
-    @test isdefined(m.PublicAPI, Symbol("@public"))
-    @test isdefined(m.PublicAPI, Symbol("@strict"))
-    @test isdefined(m.PublicAPI, :of)
-    @test !isdefined(m.PublicAPI, :Internal)
-end
-
-function test_strict_using()
-    @test isdefined(StrictUsing, Symbol("@public"))
-    check_common(StrictUsing)
-end
-
 function test_strict_import()
     @test !isdefined(StrictImport, Symbol("@public"))
-    check_common(StrictImport)
+    @test !isdefined(StrictImport, Symbol("@strict"))
+    @test !isdefined(StrictImport, :of)
+    @test isdefined(StrictImport.PublicAPI, Symbol("@public"))
+    @test isdefined(StrictImport.PublicAPI, Symbol("@strict"))
+    @test isdefined(StrictImport.PublicAPI, :of)
+    @test !isdefined(StrictImport.PublicAPI, :Internal)
 end
 
 end  # module


### PR DESCRIPTION
close #1

This implements the strategy I mentioned in https://github.com/JuliaLang/PublicAPI.jl/issues/1#issuecomment-922643365

@DilumAluthge With this PR, all my pending "easy" TODOs are done (others are harder ones like overload API declaration which needs to be designed first). I think it's ready for release for me. But we can also add docs and maybe also should setup other CIs like CompatHelper.jl.