### PR TITLE
Cleanup documentation setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PublicAPI
 
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://julialang.github.io/PublicAPI.jl/dev/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliaexperiments.github.io/PublicAPI.jl/dev/)
 
 **NOTE**: This is a proof-of-concept implementation of
 [Feature request: `Base.@public` macro for declaring a public name without needing to `export` it · Issue #42117 · JuliaLang/julia](https://github.com/JuliaLang/julia/issues/42117).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PublicAPI
 
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://julialang.github.io/PublicAPI.jl/dev/)
+
 **NOTE**: This is a proof-of-concept implementation of
 [Feature request: `Base.@public` macro for declaring a public name without needing to `export` it · Issue #42117 · JuliaLang/julia](https://github.com/JuliaLang/julia/issues/42117).
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,2 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-
-[compat]
-Documenter = "= 0.27.5"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,7 +12,7 @@ makedocs(
 )
 
 deploydocs(
-    repo = "github.com/JuliaLang/PublicAPI.jl",
+    repo = "github.com/JuliaExperiments/PublicAPI.jl",
     devbranch = "main",  # https://github.com/JuliaDocs/Documenter.jl/issues/1443
     push_preview = true,
     # See: https://juliadocs.github.io/Documenter.jl/stable/lib/public/#Documenter.deploydocs


### PR DESCRIPTION
This is a follow-up to #6. It cleans up the workaround https://github.com/JuliaLang/PublicAPI.jl/pull/6#discussion_r715991227 and "publishes" the documentation by linking it from the README.