### PR TITLE
Add API type to public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ julia> using PublicAPI
 julia> apis = PublicAPI.of(PublicAPI);
 
 julia> sort!(fullname.(apis))
-3-element Vector{Tuple{Symbol, Symbol}}:
+4-element Vector{Tuple{Symbol, Symbol}}:
  (:PublicAPI, Symbol("@public"))
  (:PublicAPI, Symbol("@strict"))
+ (:PublicAPI, :API)
  (:PublicAPI, :of)
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,4 +5,5 @@ PublicAPI
 PublicAPI.@public
 PublicAPI.@strict
 PublicAPI.of
+PublicAPI.API
 ```

--- a/src/PublicAPI.jl
+++ b/src/PublicAPI.jl
@@ -2,14 +2,26 @@ baremodule PublicAPI
 
 export @public
 
+module InternalPrelude
+function _API end
+end
+
 macro public end
 macro strict end
 
 function of end
 
+struct API
+    mod::Module
+    var::Symbol
+
+    InternalPrelude._API(mod::Module, var::Symbol) = new(mod, var)
+end
+
 module Internal
 
-using ..PublicAPI: PublicAPI
+using ..PublicAPI.InternalPrelude: _API
+using ..PublicAPI: PublicAPI, API
 import ..PublicAPI: @public, @strict
 
 include("registry.jl")
@@ -33,5 +45,6 @@ Internal.define_docstring()
 @public @public
 @public @strict
 @public of
+@public API
 
 end  # baremodule PublicAPI

--- a/test/PublicAPITests/src/test_query.jl
+++ b/test/PublicAPITests/src/test_query.jl
@@ -6,8 +6,8 @@ import ..PublicAPITests
 
 function test_of()
     apis = PublicAPI.of(PublicAPI)
-    @test sort!(nameof.(apis)) == [Symbol("@public"), Symbol("@strict"), :of]
-    @test Module.(apis) == fill(PublicAPI, 3)
+    @test sort!(nameof.(apis)) == [Symbol("@public"), Symbol("@strict"), :API, :of]
+    @test Module.(apis) == fill(PublicAPI, 4)
 end
 
 function test_recursive()


### PR DESCRIPTION
While using PublicAPI outside, I noticed that not being able to dispatch on the `API` type is a pain https://github.com/tkf/DocumentationOverview.jl/pull/5#discussion_r835848876

So, I suggest exposing the type `API`. I hide the constructor for now just in case we want to change the signature.
