### PR TITLE
Setup JuliaFormatter + reviewdog/action-suggester

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+always_for_in = true

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,0 +1,28 @@
+name: Code style
+
+on:
+  pull_request:
+
+jobs:
+  JuliaFormatter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: 1
+      - name: Install dependencies
+        run: |
+          using Pkg
+          Pkg.add("JuliaFormatter")
+        shell: julia --color=yes {0}
+      - name: Format Julia files
+        run: |
+          using JuliaFormatter
+          format(".")
+        shell: julia --color=yes --compile=min -O0 {0}
+      - name: suggester / JuliaFormatter
+        uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: JuliaFormatter
+          fail_on_error: true


### PR DESCRIPTION
This PR sets up an Action to run JuliaFormatter and uses https://github.com/reviewdog/action-suggester to post suggestions as GitHub comments. It copies the setup from https://github.com/tkf/Try.jl/pull/21. See https://github.com/tkf/Try.jl/pull/22 for what it looks like.

Note that reviewdog/action-suggester only look at the code that is changed by the PR. For example, JuliaFormatter detects #15 but I don't think it'll show up in this PR.

@DilumAluthge What do you think? Do you think it is worth the trouble? Is there a better way to do it? I actually started using this in my projects. Ref https://github.com/tkf/julia-code-style-suggesters
